### PR TITLE
added radarname edit option

### DIFF
--- a/template/run_real_data_case.py
+++ b/template/run_real_data_case.py
@@ -383,6 +383,7 @@ def generateEnKFAssimilation(cm_args, batch, assim_time, radar_data_flag=None):
                      nrdrused=n_radars,
                      rmsfcst=2,
                      hdmpfheader=cm_args.job_name,
+                     radarname=radar_data_flag[True], 
                      **kwargs
                      )
 


### PR DESCRIPTION
Not specifying the radarname option in the run_real_data_case.py file causes issues when some radar files are missing and the order of radar names in the master_config.py does not match the order of available radar files.

Explicitly specifying the radarname variable circumvents that problem.

I had realized this earlier but somehow forgot to open a pull request for it.